### PR TITLE
Fix handling of big pullrequests

### DIFF
--- a/src/main/java/org/retest/rebazer/domain/BitbucketPullRequestResponse.java
+++ b/src/main/java/org/retest/rebazer/domain/BitbucketPullRequestResponse.java
@@ -1,0 +1,13 @@
+package org.retest.rebazer.domain;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@JsonDeserialize( builder = BitbucketPullRequestResponse.BitbucketPullRequestResponseBuilder.class )
+public class BitbucketPullRequestResponse {
+	private String next;
+}

--- a/src/test/java/org/retest/rebazer/connector/BitbucketConnectorTest.java
+++ b/src/test/java/org/retest/rebazer/connector/BitbucketConnectorTest.java
@@ -53,7 +53,7 @@ class BitbucketConnectorTest {
 		cut = mock( BitbucketConnector.class );
 		final String head = "12325345923759135";
 		when( cut.getHeadOfBranch( pullRequest ) ).thenReturn( head );
-		when( cut.getLastCommonCommitId( pullRequest ) ).thenReturn( head );
+		when( cut.getLastParentCommitId( pullRequest ) ).thenReturn( head );
 		when( cut.rebaseNeeded( pullRequest ) ).thenCallRealMethod();
 
 		assertThat( cut.rebaseNeeded( pullRequest ) ).isFalse();
@@ -66,7 +66,7 @@ class BitbucketConnectorTest {
 		final String head = "12325345923759135";
 		final String lcci = "21342343253253452";
 		when( cut.getHeadOfBranch( pullRequest ) ).thenReturn( head );
-		when( cut.getLastCommonCommitId( pullRequest ) ).thenReturn( lcci );
+		when( cut.getLastParentCommitId( pullRequest ) ).thenReturn( lcci );
 		when( cut.rebaseNeeded( pullRequest ) ).thenCallRealMethod();
 
 		assertThat( cut.rebaseNeeded( pullRequest ) ).isTrue();


### PR DESCRIPTION
This should only affect PRs with more than 10 commits. In every other case, size and next are missing in the retrieved document.